### PR TITLE
Fix error handling

### DIFF
--- a/weather-plugin.sh
+++ b/weather-plugin.sh
@@ -118,17 +118,17 @@ function getData {
     # echo " " >> "$HOME/.weather.log"
     # echo `date`" ################################" >> "$HOME/.weather.log"
     RESPONSE=`curl -s $URL`
+    CODE="$?"
     if [ "$1" = "-d" ]; then
         echo $RESPONSE
         echo ""
     fi
-    CODE="$?"
     # echo "Response: $RESPONSE" >> "$HOME/.weather.log"
     RESPONSECODE=0
     if [ $CODE -eq 0 ]; then
         RESPONSECODE=`echo $RESPONSE | jq .cod`
     fi
-    if [ $CODE -ne 0 ] || [ $RESPONSECODE -ne 200 ]; then
+    if [ $CODE -ne 0 ] || [ ${RESPONSECODE:=429} -ne 200 ]; then
         if [ $CODE -ne 0 ]; then
             ERR_MSG="curl Error $CODE"
             # echo "curl Error $CODE" >> "$HOME/.weather.log"


### PR DESCRIPTION
`CODE=$?` is run after the `if`, causing it to capture the error code of `[` or `echo` instead of `curl`.

Therefore, curl failures are often "overlooked" by the script.

Before:

```
$ bwrap --bind / / --unshare-net bash weather-plugin.sh 
weather-plugin.sh: line 131: [: -ne: unary operator expected
weather-plugin.sh: line 146: [: -le: unary operator expected
weather-plugin.sh: line 154: [: -le: unary operator expected
weather-plugin.sh: line 162: [: -le: unary operator expected
weather-plugin.sh: line 170: [: -le: unary operator expected
weather-plugin.sh: line 178: [: -le: unary operator expected
weather-plugin.sh: line 182: [: -le: unary operator expected
weather-plugin.sh: line 186: [: -eq: unary operator expected
weather-plugin.sh: line 190: [: -eq: unary operator expected
weather-plugin.sh: line 199: [: -eq: unary operator expected
weather-plugin.sh: line 208: [: -le: unary operator expected
(standard_in) 1: syntax error
weather-plugin.sh: line 221: [: -le: unary operator expected
weather-plugin.sh: line 223: [: -gt: unary operator expected
weather-plugin.sh: line 225: [: -gt: unary operator expected
weather-plugin.sh: line 227: [: -gt: unary operator expected
weather-plugin.sh: line 229: [: -gt: unary operator expected
weather-plugin.sh: line 231: [: -gt: unary operator expected
weather-plugin.sh: line 233: [: -gt: unary operator expected
weather-plugin.sh: line 235: [: -gt: unary operator expected
weather-plugin.sh: line 237: [: -gt: unary operator expected
weather-plugin.sh: line 239: [: -gt: unary operator expected
weather-plugin.sh: line 241: [: -gt: unary operator expected
weather-plugin.sh: line 243: [: -gt: unary operator expected
weather-plugin.sh: line 245: [: -gt: unary operator expected
(standard_in) 1: syntax error
(standard_in) 1: syntax error
weather-plugin.sh: line 267: [: -eq: unary operator expected
weather-plugin.sh: line 293: [: : integer expression expected
(standard_in) 1: syntax error
weather-plugin.sh: line 295: [: -eq: unary operator expected
```

After:

```
$ bwrap --bind / / --unshare-net bash weather-plugin.sh 

```

Fixes #7.