### PR TITLE
Fix building URL correctly when CITY_NAME contains spaces

### DIFF
--- a/weather-plugin.sh
+++ b/weather-plugin.sh
@@ -110,7 +110,7 @@ if [ $UNITS = "kelvin" ]; then
 else
     UNIT_URL="&units=$UNITS"
 fi
-URL="api.openweathermap.org/data/2.5/weather?appid=$APIKEY$UNIT_URL&lang=$LANG&q=$CITY_NAME,$COUNTRY_CODE"
+URL="api.openweathermap.org/data/2.5/weather?appid=$APIKEY$UNIT_URL&lang=$LANG&q=$(echo $CITY_NAME| sed 's/ /%20/g'),${COUNTRY_CODE}"
 
 function getData {
     ERROR=0


### PR DESCRIPTION
Spaces in the URL must be escaped with the `%20` code. This PR simply changes the step where the URL variable is built to replace any spaces in the CITY_NAME with the correct escape code.

Without this the request just errors out.